### PR TITLE
Check if ops['fast_disk'] is empty

### DIFF
--- a/haussmeister/haussio.py
+++ b/haussmeister/haussio.py
@@ -304,7 +304,7 @@ class HaussIO(object):
             reg_file_chan2 = []
         for j in range(0,nplanes):
             ops['save_path'] = os.path.join(ops['save_path0'], 'suite2p', 'plane%d'%j)
-            if ('fast_disk' not in ops) or len(ops['fast_disk'])>0:
+            if ('fast_disk' not in ops) or len(ops['fast_disk']) == 0:
                 ops['fast_disk'] = ops['save_path0']
             ops['fast_disk'] = os.path.join(ops['fast_disk'], 'suite2p', 'plane%d'%j)
             ops['ops_path'] = os.path.join(ops['save_path'],'ops.npy')


### PR DESCRIPTION
In the current version, fast_disk is not overwritten if it contains an empty list, which produces the following error if suite2p.run_s2p is called without a declared fast_disk parameter: 
```
\envs\suite2p\lib\site-packages\haussmeister\haussio.py in tosuite2p(self, ops) [line 309]
      307             if ('fast_disk' not in ops) or len(ops['fast_disk'])>0:
      308                 ops['fast_disk'] = ops['save_path0']
--> 309             ops['fast_disk'] = os.path.join(ops['fast_disk'], 'suite2p', 'plane%d'%j)

TypeError: expected str, bytes or os.PathLike object, not list
```

By changing the operator, it should fix the problem.  In the meantime, we've found a workaround, which is to set ops['fast_disk'] to the same as ops['save_path0'] when calling run_s2p().